### PR TITLE
hotfix/projects-margin-n-height -> main

### DIFF
--- a/src/app/components/cards/project-summary-card/project-summary-card.component.html
+++ b/src/app/components/cards/project-summary-card/project-summary-card.component.html
@@ -1,12 +1,12 @@
 <p-card
-  styleClass=" w-full max-w-[480px] rounded-xl overflow-hidden mx-auto shadow-xl">
-  <ng-template pTemplate="header">
+  styleClass="h-full rounded-xl overflow-hidden shadow-xl">
+  <ng-template class="h-full" pTemplate="header">
     <div class="w-full h-32 rounded-t-xl overflow-hidden relative bg-gradient-to-r from-primary-400 to-primary-600">
   <img *ngIf="showImage" [src]="imageUrl" alt="Banner do Projeto" class="absolute inset-0 w-full h-full object-cover" (error)="onImageError()" />
     </div>
   </ng-template>
   <ng-template pTemplate="content">
-    <div class=" max-w-xs  md:max-w-md mx-auto">
+    <div class="flex flex-col h-full justify-between max-w-xs  md:max-w-md">
       <h3 class="text-lg font-bold text-800 mb-1 overflow-hidden text-ellipsis whitespace-nowrap min-h-[2.5rem]">{{ project.name }}</h3>
 
       <div class="mb-1">

--- a/src/app/pages/projects/projects.component.html
+++ b/src/app/pages/projects/projects.component.html
@@ -34,8 +34,8 @@
     (closeFilters)="toggleFilters()"
   ></app-project-filter>
 
-  <div class="flex justify-center mt-4 sm:mt-6">
-    <div class="justify-center grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-4 items-stretch w-full">
+  <div class="mt-4 sm:mt-6">
+    <div class="m-0 justify-between grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-2 items-stretch w-full">
       <app-project-summary-card
         *ngFor="let project of projects; let i = index"
         [project]="project"


### PR DESCRIPTION
# Summary

I am oppening this pull request in order to fix a margin and height issue on the projects page that were happening in `ProjectsComponent` and `ProjectsSummaryCardComponent`

## Approach

I have fixed it through fixing native margin of grid in tailwind css and also making a standard h-full for the card components.

## Screenshots

**Fix:**
<img width="1575" height="177" alt="image" src="https://github.com/user-attachments/assets/53f97929-6187-41dd-bac7-9d69340e8de1" />

**Broken:**
<img width="1608" height="163" alt="image" src="https://github.com/user-attachments/assets/40625920-4aaf-4d70-b3a8-0ac94f072427" />

**Fix:**
<img width="1624" height="102" alt="image" src="https://github.com/user-attachments/assets/2781c606-4265-4e9b-8dd7-fe7bce29d3e7" />


**Broken:**
<img width="1545" height="182" alt="image" src="https://github.com/user-attachments/assets/df7b0c2c-b6f6-4394-b1af-6ac25c0997e5" />

---

## TODO

I think the buttons on the p-body and p-content should also be fixed to be fixed in the bottom part of the card, this is a thing that I still need to think how to fix:

<img width="1565" height="147" alt="image" src="https://github.com/user-attachments/assets/6929f433-f43d-487b-ba66-44f24acca50f" />
